### PR TITLE
Add agent to client constructor options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import https from 'https';
+import http = require('http');
+import https = require('https');
 
 export type Variables = { [key: string]: any }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import http from 'http';
+import https from 'https';
+
 export type Variables = { [key: string]: any }
 
 export interface Headers {
@@ -5,6 +8,7 @@ export interface Headers {
 }
 
 export interface Options {
+  agent?: false | http.Agent | https.Agent;
   method?: RequestInit['method']
   headers?: Headers
   mode?: RequestInit['mode']


### PR DESCRIPTION
It looks like there's some hangup around adding an `agent` property to the constructor options, but I'm not sure I entirely understand it.

For instance, Fredy C commented in  https://github.com/prisma/graphql-request/issues/84 that:

> I guess that my concern is about importing https module which would work fine in node environment, but when building eg. with Webpack, it would suddenly force users to somehow mock that module. From my experience even using inline require does not work because Webpack will see it.

However, if you like at the typings for the `request` module, they're doing the same thing so I'm not sure what the hangup is?

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/request/index.d.ts#L21