### PR TITLE
Don't append stringified JSON in the error message

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export class ClientError extends Error {
   request: GraphQLRequestContext
 
   constructor (response: GraphQLResponse, request: GraphQLRequestContext) {
-    const message = `${ClientError.extractMessage(response)}: ${JSON.stringify({ response, request })}`
+    const message = ClientError.extractMessage(response)
 
     super(message)
 


### PR DESCRIPTION
Adding the request and response objects in the error message makes it too long and it's redundant because those objects have their own properties.