### PR TITLE
feat: Improved support for Apollo Server

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface GraphQLError {
   message: string
   locations: { line: number, column: number }[]
   path: string[]
+  [key: string]: any;
 }
 
 export interface GraphQLResponse {


### PR DESCRIPTION
Apollo Server has some more stuff on their ApolloError which is useful to be able to access without typecasting. Specifically in my case I want to access `.extensions.code`.