### PR TITLE
Enable headers in charset content-type test

### DIFF
--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -62,7 +62,7 @@ test('minimal raw query with response headers', async () => {
 
 test('content-type with charset', async () => {
   const { data } = ctx.res({
-    // headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
     body: {
       data: {
         me: {


### PR DESCRIPTION
While investigating an error I'm seeing, I noticed this commented out header in the test for supporting content-type headers with charset. I thought maybe the test was failing, but adding the header works just fine. 