### PR TITLE
[WIP] feat(wip:subsciption): Introducing subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
   "dependencies": {
     "cross-fetch": "^3.0.6",
     "extract-files": "^9.0.0",
-    "form-data": "^3.0.0"
+    "form-data": "^3.0.0",
+    "graphql-ws": "^5.3.0",
+    "subscriptions-transport-ws": "^0.9.19"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
+import assert from 'assert'
 import crossFetch, * as CrossFetch from 'cross-fetch'
 import { print } from 'graphql/language/printer'
 import createRequestBody from './createRequestBody'
-import { ClientError, GraphQLError, RequestDocument, Variables } from './types'
+import {
+  ClientError,
+  RequestDocument,
+  Variables,
+  SubscribePayload,
+  SubscribeOptions,
+  SubsciptionProtocol
+} from './types'
 import * as Dom from './types.dom'
 
 export { ClientError } from './types'
@@ -107,6 +115,29 @@ export class GraphQLClient {
     }
 
     return this
+  }
+
+  subscribe<T = any, V = Variables, E = any>(
+    payload: SubscribePayload<V, E>,
+    { protocol }: SubscribeOptions<T>
+  ): () => void {
+    // TODO: create class property protocol
+    const _protocol = protocol || this.protocol
+    // assertion is for js users
+    assert(
+      Object.values(SubsciptionProtocol).includes(protocol as SubsciptionProtocol),
+      `options.protocol should be SubsciptionProtocol: ${Object.values(SubsciptionProtocol).join(', ')}`
+    )
+    if (_protocol === SubsciptionProtocol.SUBSCRIPTION_TRANSPORT_WS) {
+      // TODO: subscribe by subscription-transport-ws client
+    } else if (_protocol === SubsciptionProtocol.GRAPHQL_WS) {
+      // TODO: subscribe by graphql-ws client
+    } else {
+      // Assertion is passed but behavior is not implemented.
+      throw Error(
+        'Unchecked protocol. This is a bug of graphql-request. Create an issue on https://github.com/prisma-labs/graphql-request'
+      )
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import { DocumentNode } from 'graphql/language/ast'
+import { DocumentNode } from 'graphql'
 
-export type Variables = { [key: string]: any }
+export type Variables = Record<string, any>
 
 export interface GraphQLError {
   message: string
@@ -28,7 +28,7 @@ export class ClientError extends Error {
   constructor(response: GraphQLResponse, request: GraphQLRequestContext) {
     const message = `${ClientError.extractMessage(response)}: ${JSON.stringify({
       response,
-      request,
+      request
     })}`
 
     super(message)
@@ -54,3 +54,28 @@ export class ClientError extends Error {
 }
 
 export type RequestDocument = string | DocumentNode
+
+export interface SubscribePayload<V = Variables, E = any> {
+  readonly document: RequestDocument
+  readonly operationName?: string
+  readonly variables?: V
+  readonly extensions?: E
+}
+
+export interface Observer<T> {
+  next?(value: T): void
+  error?(errorValue: any): void
+  complete?(): void
+}
+
+export enum SubsciptionProtocol {
+  // REF: https://github.com/apollographql/subscriptions-transport-ws
+  SUBSCRIPTION_TRANSPORT_WS = 'subscription-transport-ws',
+  // REF: https://github.com/enisdenjo/graphql-ws
+  GRAPHQL_WS = 'graphql-ws'
+}
+
+export interface SubscribeOptions<T> {
+  readonly observer: Observer<T>
+  readonly protocol?: SubsciptionProtocol
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,6 +3026,11 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
+graphql-ws@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.3.0.tgz#345f73686b639735f1f4ef0b9ea28e17c7f6a745"
+  integrity sha512-53MbSTOmgx5i6hf3DHVD5PrXix1drDmt2ja8MW7NG+aTpKGzkXVLyNcyNpxme4SK8jVtIV6ZIHkiwirqN0efpw==
+
 graphql@^15.3.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
@@ -5636,6 +5641,17 @@ subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.16:
     symbol-observable "^1.0.4"
     ws "^5.2.0"
 
+subscriptions-transport-ws@^0.9.19:
+  version "0.9.19"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz#10ca32f7e291d5ee8eb728b9c02e43c52606cdcf"
+  integrity sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 supports-color@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
@@ -6258,6 +6274,11 @@ ws@^5.2.0:
   integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
   dependencies:
     async-limiter "~1.0.0"
+
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"
+  integrity sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==
 
 ws@^6.0.0:
   version "6.2.1"


### PR DESCRIPTION
# 🚧 Work In Progress - Introducing subscription

This aims to resolve #77.

## Background

The [GraphQL specification](http://spec.graphql.org/) deliberately does not specify the transport layer.

Currently, WebSocket and HTTP are chosen by the majority, with these two different approaches.

1. Full WebSocket: query, mutation, and subscription all on WebSocket.
2. Hybrid: HTTP for query and mutation, while WebSocket for subscription. (Though theoretically arbitrary protocol can be chosen, there isn't another combination adopted wide enough.)

## Opinion

As `graphql-request` has used HTTP for query and mutation, **I assume the "Hybrid" approach is suitable** for subscription, at least for now.

## Protocol

For GraphQL over WebSocket, two different protocols exist, suggested by the community and adopted wide enough.

A. [`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws) ([protocol spec](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md)): This is a legacy and not actively maintained, but many servers have implemented it.
B. [`graphql-ws`](https://github.com/enisdenjo/graphql-ws) ([protocol spec](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)): This is newly suggested one.

Those two are not compatible.

**Thus `graphql-request` lets users choose one over the other by passing options.**

## Implementation (Pseudo Code)

```ts
class GraphQLClient {
  
  subscribe(
    payload: SubscribePayload,
    options: SubscribeOptions
  ): () => void
  
  unsubscribeAll(): void
}
```

`subscribe` returns a function that a consumer should call to unsubscribe.

`SubscribeOptions` includes `Observer` proposed by [tc39/proposal-observable](https://github.com/tc39/proposal-observable#observer), which defines how to process received data, error, and completion.

## TODOs

- [ ] Add more fields on `SubscribeOptions`
- [ ] Refactor constructor of the class `GraphQLClient` for configuring subscription options.
- [ ] Create a facade function for users to import solely 
- [ ] Write docs
- [ ] Test