### PR TITLE
feat: Allow to pass extensions to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ request({
   document: query,
   variables: variables,
   requestHeaders: headers,
+  extensions: extensions,
 }).then((data) => console.log(data))
 ```
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:node": "jest --testEnvironment node",
     "test:dom": "jest --testEnvironment jsdom",
     "test": "yarn test:node && yarn test:dom",
+    "test:updateSnapshot": "yarn jest --testEnvironment node --updateSnapshot",
     "test:coverage": "yarn test --coverage",
     "release:stable": "dripip stable",
     "release:preview": "dripip preview",
@@ -53,7 +54,6 @@
     "graphql": "14 - 16"
   },
   "devDependencies": {
-    "abort-controller": "^3.0.0",
     "@prisma-labs/prettier-config": "^0.1.0",
     "@types/body-parser": "^1.19.1",
     "@types/express": "^4.17.13",
@@ -61,6 +61,7 @@
     "@types/graphql-upload": "^8.0.6",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.4.3",
+    "abort-controller": "^3.0.0",
     "apollo-server-express": "^3.5.0",
     "body-parser": "^1.19.0",
     "doctoc": "^2.0.1",

--- a/src/createRequestBody.ts
+++ b/src/createRequestBody.ts
@@ -19,9 +19,14 @@ const isExtractableFileEnhanced = (value: any): value is ExtractableFile | { pip
 export default function createRequestBody(
   query: string | string[],
   variables?: Variables | Variables[],
-  operationName?: string
+  operationName?: string,
+  extensions?: any
 ): string | FormData {
-  const { clone, files } = extractFiles({ query, variables, operationName }, '', isExtractableFileEnhanced)
+  const { clone, files } = extractFiles(
+    { query, variables, operationName, extensions },
+    '',
+    isExtractableFileEnhanced
+  )
 
   if (files.size === 0) {
     if (!Array.isArray(query)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,8 @@ export class ClientError extends Error {
   }
 }
 
+export type GraphQLExtensions = Record<string, any>
+
 export type RequestDocument = string | DocumentNode
 
 export type BatchRequestDocument<V = Variables> = {
@@ -67,6 +69,7 @@ export type RawRequestOptions<V = Variables> = {
   variables?: V
   requestHeaders?: Dom.RequestInit['headers']
   signal?: Dom.RequestInit['signal']
+  extensions?: GraphQLExtensions
 }
 
 export type RequestOptions<V = Variables> = {
@@ -74,6 +77,7 @@ export type RequestOptions<V = Variables> = {
   variables?: V
   requestHeaders?: Dom.RequestInit['headers']
   signal?: Dom.RequestInit['signal']
+  extensions?: GraphQLExtensions
 }
 
 export type BatchRequestsOptions<V = Variables> = {

--- a/tests/__helpers.ts
+++ b/tests/__helpers.ts
@@ -6,7 +6,7 @@ import { graphqlUploadExpress } from 'graphql-upload'
 import { createServer, Server } from 'http'
 import { JsonObject } from 'type-fest'
 
-type CapturedRequest = Pick<Request, 'headers' | 'method' | 'body'>
+type CapturedRequest = Pick<Request, 'headers' | 'method' | 'body' | 'url'>
 
 type Context<S extends MockSpec | MockSpecBatch = MockSpec> = {
   server: Application
@@ -27,11 +27,13 @@ type MockSpecBody = {
 type MockSpec = {
   headers?: Record<string, string>
   body?: MockSpecBody
+  url: string
 }
 
 export type MockSpecBatch = {
   headers?: Record<string, string>
   body?: MockSpecBody[]
+  url: string
 }
 
 type MockResult<Spec extends MockSpec | MockSpecBatch = MockSpec> = {
@@ -40,6 +42,7 @@ type MockResult<Spec extends MockSpec | MockSpecBatch = MockSpec> = {
     method: string
     headers: Record<string, string>
     body: JsonObject
+    url: string
   }[]
 }
 
@@ -68,6 +71,7 @@ export function setupTestServer<T extends MockSpec | MockSpecBatch = MockSpec>(d
           method: req.method,
           headers: req.headers,
           body: req.body,
+          url: req.url,
         })
         if (spec?.headers) {
           Object.entries(spec.headers).forEach(([name, value]) => {

--- a/tests/__snapshots__/document-node.test.ts.graphql_14.snap
+++ b/tests/__snapshots__/document-node.test.ts.graphql_14.snap
@@ -22,6 +22,7 @@ Object {
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
       },
       "method": "POST",
+      "url": "/",
     },
   ],
   "spec": Object {
@@ -30,6 +31,7 @@ Object {
         "foo": 1,
       },
     },
+    "url": "/",
   },
 }
 `;

--- a/tests/__snapshots__/document-node.test.ts.graphql_15.snap
+++ b/tests/__snapshots__/document-node.test.ts.graphql_15.snap
@@ -22,6 +22,7 @@ Object {
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
       },
       "method": "POST",
+      "url": "/",
     },
   ],
   "spec": Object {
@@ -30,6 +31,7 @@ Object {
         "foo": 1,
       },
     },
+    "url": "/",
   },
 }
 `;

--- a/tests/__snapshots__/document-node.test.ts.graphql_16.snap
+++ b/tests/__snapshots__/document-node.test.ts.graphql_16.snap
@@ -21,6 +21,7 @@ Object {
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
       },
       "method": "POST",
+      "url": "/",
     },
   ],
   "spec": Object {
@@ -29,6 +30,7 @@ Object {
         "foo": 1,
       },
     },
+    "url": "/",
   },
 }
 `;

--- a/tests/__snapshots__/gql.test.ts.graphql_14.snap
+++ b/tests/__snapshots__/gql.test.ts.graphql_14.snap
@@ -21,6 +21,7 @@ Object {
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
       },
       "method": "POST",
+      "url": "/",
     },
   ],
   "spec": Object {
@@ -29,6 +30,7 @@ Object {
         "foo": 1,
       },
     },
+    "url": "/",
   },
 }
 `;

--- a/tests/__snapshots__/gql.test.ts.graphql_15.snap
+++ b/tests/__snapshots__/gql.test.ts.graphql_15.snap
@@ -21,6 +21,7 @@ Object {
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
       },
       "method": "POST",
+      "url": "/",
     },
   ],
   "spec": Object {
@@ -29,6 +30,7 @@ Object {
         "foo": 1,
       },
     },
+    "url": "/",
   },
 }
 `;

--- a/tests/__snapshots__/gql.test.ts.graphql_16.snap
+++ b/tests/__snapshots__/gql.test.ts.graphql_16.snap
@@ -20,6 +20,7 @@ Object {
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
       },
       "method": "POST",
+      "url": "/",
     },
   ],
   "spec": Object {
@@ -28,6 +29,7 @@ Object {
         "foo": 1,
       },
     },
+    "url": "/",
   },
 }
 `;

--- a/tests/batching.test.ts
+++ b/tests/batching.test.ts
@@ -8,6 +8,7 @@ test('minimal double query', async () => {
   const firstResult = { me: { id: 'some-id' } }
   const secondResult = { me: { id: 'another-id' } }
   const okq = ctx.res({
+    url: '/',
     body: [{ data: firstResult }, { data: secondResult }],
   })
 
@@ -22,6 +23,7 @@ test('minimal double query', async () => {
 
 test('basic error', async () => {
   ctx.res({
+    url: '/',
     body: [
       {
         errors: {
@@ -57,6 +59,7 @@ test('successful query with another which make an error', async () => {
   }
 
   ctx.res({
+    url: '/',
     body: [firstResult, secondResult],
   })
 

--- a/tests/document-node.test.ts
+++ b/tests/document-node.test.ts
@@ -5,7 +5,7 @@ import { setupTestServer } from './__helpers'
 const ctx = setupTestServer()
 
 it('accepts graphql DocumentNode as alternative to raw string', async () => {
-  const mock = ctx.res({ body: { data: { foo: 1 } } })
+  const mock = ctx.res({ url: '/', body: { data: { foo: 1 } } })
   await request(
     ctx.url,
     graphqlTag`

--- a/tests/extensions.test.ts
+++ b/tests/extensions.test.ts
@@ -1,0 +1,65 @@
+import { GraphQLClient, request } from '../src'
+import { setupTestServer } from './__helpers'
+
+const ctx = setupTestServer()
+
+describe('using class', () => {
+  describe('post', () => {
+    test('without extensions set', async () => {
+      const mock = ctx.res()
+      const client = new GraphQLClient(ctx.url)
+      await client.request({ document: `{ me { id } }` })
+
+      expect(mock.requests[0].body).toEqual({ query: `{ me { id } }` })
+    })
+
+    test('with extensions set', async () => {
+      const mock = ctx.res()
+      const client = new GraphQLClient(ctx.url)
+      await client.request({ document: `{ me { id } }`, extensions: { ext1: { value: 'yes' } } })
+
+      expect(mock.requests[0].body).toEqual({
+        query: `{ me { id } }`,
+        extensions: { ext1: { value: 'yes' } },
+      })
+    })
+  })
+
+  describe('get', () => {
+    test('without extensions set', async () => {
+      const mock = ctx.res()
+      const client = new GraphQLClient(ctx.url, { method: 'GET' })
+      await client.request({ document: `{ me { id } }` })
+
+      expect(mock.requests[0].url).toEqual(`/?query=${encodeURIComponent(`{ me { id } }`)}`)
+    })
+
+    test('with extensions set', async () => {
+      const mock = ctx.res()
+      const client = new GraphQLClient(ctx.url, { method: 'GET' })
+      await client.request({ document: `{ me { id } }`, extensions: { ext1: { value: 'yes' } } })
+
+      expect(mock.requests[0].url).toEqual(
+        `/?query=${encodeURIComponent(`{ me { id } }`)}&extensions=${encodeURIComponent(
+          JSON.stringify({ ext1: { value: 'yes' } })
+        )}`
+      )
+    })
+  })
+})
+
+describe('using request function', () => {
+  test('without extensions set', async () => {
+    const mock = ctx.res()
+    await request({ url: ctx.url, document: `{ me { id } }` })
+
+    expect(mock.requests[0].body).toEqual({ query: `{ me { id } }` })
+  })
+
+  test('with extensions set', async () => {
+    const mock = ctx.res()
+    await request({ url: ctx.url, document: `{ me { id } }`, extensions: { ext1: { value: 'yes' } } })
+
+    expect(mock.requests[0].body).toEqual({ query: `{ me { id } }`, extensions: { ext1: { value: 'yes' } } })
+  })
+})

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -6,6 +6,7 @@ const ctx = setupTestServer()
 
 test('minimal query', async () => {
   const { data } = ctx.res({
+    url: '/',
     body: {
       data: {
         me: {
@@ -20,6 +21,7 @@ test('minimal query', async () => {
 
 test('minimal raw query', async () => {
   const { extensions, data } = ctx.res({
+    url: '/',
     body: {
       data: {
         me: {
@@ -37,6 +39,7 @@ test('minimal raw query', async () => {
 
 test('minimal raw query with response headers', async () => {
   const { headers: reqHeaders, body } = ctx.res({
+    url: '/',
     headers: {
       'Content-Type': 'application/json',
       'X-Custom-Header': 'test-custom-header',
@@ -61,6 +64,7 @@ test('minimal raw query with response headers', async () => {
 
 test('content-type with charset', async () => {
   const { data } = ctx.res({
+    url: '/',
     // headers: { 'Content-Type': 'application/json; charset=utf-8' },
     body: {
       data: {
@@ -76,6 +80,7 @@ test('content-type with charset', async () => {
 
 test('basic error', async () => {
   ctx.res({
+    url: '/',
     body: {
       errors: {
         message: 'Syntax Error GraphQL request (1:1) Unexpected Name "x"\n\n1: x\n   ^\n',
@@ -98,6 +103,7 @@ test('basic error', async () => {
 
 test('basic error with raw request', async () => {
   ctx.res({
+    url: '/',
     body: {
       errors: {
         message: 'Syntax Error GraphQL request (1:1) Unexpected Name "x"\n\n1: x\n   ^\n',
@@ -127,6 +133,7 @@ test.skip('extra fetch options', async () => {
 
   const client = new GraphQLClient(ctx.url, options)
   const { requests } = ctx.res({
+    url: '/',
     body: { data: { test: 'test' } },
   })
   await client.request('{ test }')

--- a/tests/gql.test.ts
+++ b/tests/gql.test.ts
@@ -6,7 +6,7 @@ const ctx = setupTestServer()
 
 describe('gql', () => {
   it('passthrough allowing benefits of tooling for gql template tag', async () => {
-    const mock = ctx.res({ body: { data: { foo: 1 } } })
+    const mock = ctx.res({ url: '/', body: { data: { foo: 1 } } })
     await request(
       ctx.url,
       gql`query allUsers {

--- a/tests/signal.test.ts
+++ b/tests/signal.test.ts
@@ -21,6 +21,7 @@ it('should abort a request when the signal is defined in the GraphQLClient', asy
 it('should abort a request when the signal is defined in GraphQLClient and after the request has been sent', async () => {
   const abortController = new AbortController()
   ctx.res({
+    url: '/',
     body: {
       data: {
         me: {
@@ -137,6 +138,7 @@ it('should abort a request', async () => {
 it('should abort a request after the request has been sent', async () => {
   const abortController = new AbortController()
   ctx.res({
+    url: '/',
     body: {
       data: {
         me: {
@@ -180,6 +182,7 @@ it('should abort a raw request', async () => {
 it('should abort a raw request after the request has been sent', async () => {
   const abortController = new AbortController()
   ctx.res({
+    url: '/',
     body: {
       data: {
         me: {
@@ -223,6 +226,7 @@ it('should abort batch requests', async () => {
 it('should abort batch requests after a request has been sent', async () => {
   const abortController = new AbortController()
   ctx.res({
+    url: '/',
     body: {
       data: {
         me: {

--- a/update-snapshots.sh
+++ b/update-snapshots.sh
@@ -1,7 +1,7 @@
 install_and_test()
 {
   yarn add graphql@"$((GRAPHQL_VERSION))" --dev
-  yarn test
+  yarn test:updateSnapshot
 }
 
 export GRAPHQL_VERSION=14


### PR DESCRIPTION
While trying to get [APQ](https://www.apollographql.com/docs/apollo-server/performance/apq/) to work somehow with graphql-request, I noticed that it is currently not possible to pass extensions to the queries/mutations sent to the API.

This PR adds this capability:

```js
client.request({ url, document, extensions: { myExt1: { value: 1 } } });
```

Basically, you can pass _anything_ as `extensions` and it will be included in the payload as-is:

```js
{
  operationName: 'MyQuery',
  variables: null,
  query: '...',
  extensions: {
    myExt1: {
      value: 1
    }
  }
}
```

This should allow experimentation in user-space with extensions.

Note: This also updates the `./update-snapshots.sh` script to actually update the snapshots :sweat_smile: it was only running tests for all envs, but not really re-creating the snapshots.