### PR TITLE
feat: Provide request headers in ClientError.request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -370,7 +370,7 @@ async function makeRequest<T = any, V = Variables>({
   fetchOptions: Dom.RequestInit
 }): Promise<{ data: T; extensions?: any; headers: Dom.Headers; status: number }> {
   const fetcher = method.toUpperCase() === 'POST' ? post : get
-  const isBathchingQuery = Array.isArray(query)
+  const isBatchingQuery = Array.isArray(query)
 
   const response = await fetcher({
     url,
@@ -384,12 +384,12 @@ async function makeRequest<T = any, V = Variables>({
   const result = await getResult(response)
 
   const successfullyReceivedData =
-    isBathchingQuery && Array.isArray(result) ? !result.some(({ data }) => !data) : !!result.data
+    isBatchingQuery && Array.isArray(result) ? !result.some(({ data }) => !data) : !!result.data
 
   if (response.ok && !result.errors && successfullyReceivedData) {
     const { headers, status } = response
     return {
-      ...(isBathchingQuery ? { data: result } : result),
+      ...(isBatchingQuery ? { data: result } : result),
       headers,
       status,
     }
@@ -397,7 +397,7 @@ async function makeRequest<T = any, V = Variables>({
     const errorResult = typeof result === 'string' ? { error: result } : result
     throw new ClientError(
       { ...errorResult, status: response.status, headers: response.headers },
-      { query, variables }
+      { query, variables, headers: headers || {} }
     )
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface GraphQLResponse<T = any> {
 export interface GraphQLRequestContext<V = Variables> {
   query: string | string[]
   variables?: V
+  headers: Record<string, string>;
 }
 
 export class ClientError extends Error {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface GraphQLResponse<T = any> {
 export interface GraphQLRequestContext<V = Variables> {
   query: string | string[]
   variables?: V
-  headers: Record<string, string>;
+  headers: HeadersInit;
 }
 
 export class ClientError extends Error {

--- a/tests/batching.test.ts
+++ b/tests/batching.test.ts
@@ -38,7 +38,7 @@ test('basic error', async () => {
   })
 
   await expect(batchRequests(ctx.url, [{ document: `x` }])).rejects.toMatchInlineSnapshot(
-    `[Error: GraphQL Error (Code: 200): {"response":{"0":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]}},"status":200,"headers":{}},"request":{"query":["x"],"variables":[null]}}]`
+    `[Error: GraphQL Error (Code: 200): {"response":{"0":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]}},"status":200,"headers":{}},"request":{"query":["x"],"variables":[null],"headers":{}}}]`
   )
 })
 
@@ -63,26 +63,6 @@ test('successful query with another which make an error', async () => {
   await expect(
     batchRequests(ctx.url, [{ document: `{ me { id } }` }, { document: `x` }])
   ).rejects.toMatchInlineSnapshot(
-    `[Error: GraphQL Error (Code: 200): {"response":{"0":{"data":{"me":{"id":"some-id"}}},"1":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]}},"status":200,"headers":{}},"request":{"query":["{ me { id } }","x"],"variables":[null,null]}}]`
+    `[Error: GraphQL Error (Code: 200): {"response":{"0":{"data":{"me":{"id":"some-id"}}},"1":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]}},"status":200,"headers":{}},"request":{"query":["{ me { id } }","x"],"variables":[null,null],"headers":{}}}]`
   )
 })
-
-// test('basic error with raw request', async () => {
-//   ctx.res({
-//     body: {
-//       errors: {
-//         message: 'Syntax Error GraphQL request (1:1) Unexpected Name "x"\n\n1: x\n   ^\n',
-//         locations: [
-//           {
-//             line: 1,
-//             column: 1,
-//           },
-//         ],
-//       },
-//     },
-//   })
-//   const res = await rawRequest(ctx.url, `x`).catch((x) => x)
-//   expect(res).toMatchInlineSnapshot(
-//     `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x"}}]`
-//   )
-// })

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -93,7 +93,32 @@ test('basic error', async () => {
   const res = await request(ctx.url, `x`).catch((x) => x)
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x"}}]`
+    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x","headers":{}}}]`
+  )
+})
+
+test('basic error with request headers', async () => {
+  ctx.res({
+    body: {
+      errors: {
+        message: 'Syntax Error GraphQL request (1:1) Unexpected Name "x"\n\n1: x\n   ^\n',
+        locations: [
+          {
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+    },
+  })
+
+  const res = await request(ctx.url, `x`, undefined, {
+    'X-Custom-Header': 'test-custom-header',
+  }).catch((x) => x)
+
+  expect(res.request.headers).toMatchObject({ 'X-Custom-Header': 'test-custom-header' })
+  expect(res).toMatchInlineSnapshot(
+    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x","headers":{"X-Custom-Header":"test-custom-header"}}}]`
   )
 })
 
@@ -113,7 +138,7 @@ test('basic error with raw request', async () => {
   })
   const res = await rawRequest(ctx.url, `x`).catch((x) => x)
   expect(res).toMatchInlineSnapshot(
-    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x"}}]`
+    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x","headers":{}}}]`
   )
 })
 


### PR DESCRIPTION
For more context see: https://github.com/tannerlinsley/react-query/discussions/3324

It seems logical to me that you would also be able to see your request headers in the error response aside from just the GQL body that's being sent. This is how the browser, fastify, express etc all tackle it.

Does this sound like an idea? Let me know of there is something else I can do here.