### PR TITLE
Add hooks functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
     - [Batching](#batching)
     - [Cancellation](#cancellation)
     - [Middleware](#middleware)
+    - [Hooks](#hooks)
     - [ErrorPolicy](#errorpolicy)
       - [None (default)](#none-default)
       - [Ignore](#ignore)
@@ -756,6 +757,35 @@ function middleware(response: Response<unknown>) {
 }
 
 const client = new GraphQLClient(endpoint, { responseMiddleware: middleware })
+```
+
+### Hooks
+
+Hooks allow you to get better observability into your requests.
+
+```ts
+const client = new GraphQLClient(endpoint, {
+  hooks: {
+    beforeRequest(req) {
+      const requestId = Math.random().toString(16).slice(2)
+      console.log(`${req.operationName}:${requestId} started`)
+      return {
+        requestId,
+        startTime: new Date(),
+      }
+    },
+    onError(err, req, state) {
+      if (err instanceof Error) {
+        const durationMs = new Date().getTime() - state.startTime.getTime()
+        console.error(`${req.operationName}:${state.requestId} -> ${err.message} (${durationMs}ms)`)
+      }
+    },
+    onCompleted(res, req, state) {
+      const durationMs = new Date().getTime() - state.startTime.getTime()
+      console.log(`${req.operationName}:${state.requestId} -> ${res.status} (${durationMs}ms)`)
+    },
+  },
+})
 ```
 
 ### ErrorPolicy

--- a/examples/hooks.ts
+++ b/examples/hooks.ts
@@ -1,0 +1,45 @@
+import { GraphQLClient } from '../src'
+;(async function () {
+  const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
+
+  const graphQLClient = new GraphQLClient(endpoint, {
+    hooks: {
+      beforeRequest(req) {
+        const requestId = Math.random().toString(16).slice(2)
+        console.log(`${req.operationName}:${requestId} started`)
+        return {
+          requestId,
+          startTime: new Date(),
+        }
+      },
+      onError(err, req, state) {
+        if (err instanceof Error) {
+          const durationMs = new Date().getTime() - state.startTime.getTime()
+          console.error(`${req.operationName}:${state.requestId} -> ${err.message} (${durationMs}ms)`)
+        }
+      },
+      onCompleted(res, req, state) {
+        const durationMs = new Date().getTime() - state.startTime.getTime()
+        console.log(`${req.operationName}:${state.requestId} -> ${res.status} (${durationMs}ms)`)
+      },
+    },
+  })
+
+  const query = /* GraphQL */ `
+    {
+      Movie(title: "Inception") {
+        releaseDate
+        actors {
+          name
+        }
+      }
+    }
+  `
+
+  interface TData {
+    Movie: { releaseDate: string; actors: Array<{ name: string }> }
+  }
+
+  const data = await graphQLClient.request<TData>(query)
+  console.log(JSON.stringify(data, undefined, 2))
+})().catch((error) => console.error(error))

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,10 +68,11 @@ export interface Response<T> {
   status: number
 }
 
-export type PatchedRequestInit = Omit<Dom.RequestInit, 'headers'> & {
+export type PatchedRequestInit<H extends HooksState> = Omit<Dom.RequestInit, 'headers'> & {
   headers?: MaybeFunction<Dom.RequestInit['headers']>
   requestMiddleware?: RequestMiddleware
   responseMiddleware?: (response: Response<unknown> | Error) => void
+  hooks?: Hooks<H>
 }
 
 export type BatchRequestDocument<V extends Variables = Variables> = {
@@ -132,3 +133,27 @@ export type VariablesAndRequestHeaders<V extends Variables> = V extends Record<a
   : keyof RemoveIndex<V> extends never // do we get an empty variables object?
   ? [variables?: V, requestHeaders?: Dom.RequestInit['headers']]
   : [variables: V, requestHeaders?: Dom.RequestInit['headers']]
+
+export type HooksState = Record<string, any> | undefined
+
+export type BeforeRequestHook<H extends HooksState = undefined> = (
+  request: RequestExtendedInit
+) => H | Promise<H> | void
+
+export type OnErrorHook<H extends HooksState = undefined> = (
+  error: unknown,
+  request: RequestExtendedInit,
+  requestState: H
+) => void | Promise<void>
+
+export type OnCompletedHook<H extends HooksState = undefined> = (
+  response: Response<unknown>,
+  request: RequestExtendedInit,
+  requestState: H
+) => void | Promise<void>
+
+export type Hooks<H extends HooksState = undefined> = {
+  beforeRequest?: BeforeRequestHook<H>
+  onCompleted?: OnCompletedHook<H>
+  onError?: OnErrorHook<H>
+}


### PR DESCRIPTION
I needed to log the request times for a project I'm working on. I wasn't able to use the existing middleware to track durations because the `responseMiddleware` doesn't have access to the request object. I extended the constructor options to allow users to pass functions that hook into the request lifecycle. You can return state from the `beforeRequest` hook to track it for the duration of the request. There are no breaking changes with this new functionality.

```ts
const client = new GraphQLClient(endpoint, {
  hooks: {
    beforeRequest(req) {
      const requestId = Math.random().toString(16).slice(2)
      console.log(`${req.operationName}:${requestId} started`)
      return {
        requestId,
        startTime: new Date(),
      }
    },
    onError(err, req, state) {
      if (err instanceof Error) {
        const durationMs = new Date().getTime() - state.startTime.getTime()
        console.error(`${req.operationName}:${state.requestId} -> ${err.message} (${durationMs}ms)`)
      }
    },
    onCompleted(res, req, state) {
      const durationMs = new Date().getTime() - state.startTime.getTime()
      console.log(`${req.operationName}:${state.requestId} -> ${res.status} (${durationMs}ms)`)
    },
  },
})
```