### PR TITLE
fix: check if property errors from response is an empty array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -482,7 +482,8 @@ async function makeRequest<T = any, V extends Variables = Variables>({
     isBatchingQuery && Array.isArray(result) ? !result.some(({ data }) => !data) : !!result.data
 
   const successfullyPassedErrorPolicy =
-    !result.errors || !result.errors.length || fetchOptions.errorPolicy === 'all' || fetchOptions.errorPolicy === 'ignore'
+    !result.errors || (Array.isArray(result.errors) && !result.errors.length)
+    || fetchOptions.errorPolicy === 'all' || fetchOptions.errorPolicy === 'ignore'
 
   if (response.ok && successfullyPassedErrorPolicy && successfullyReceivedData) {
     const { headers, status } = response

--- a/src/index.ts
+++ b/src/index.ts
@@ -482,8 +482,10 @@ async function makeRequest<T = any, V extends Variables = Variables>({
     isBatchingQuery && Array.isArray(result) ? !result.some(({ data }) => !data) : !!result.data
 
   const successfullyPassedErrorPolicy =
-    !result.errors || (Array.isArray(result.errors) && !result.errors.length)
-    || fetchOptions.errorPolicy === 'all' || fetchOptions.errorPolicy === 'ignore'
+    !result.errors ||
+    (Array.isArray(result.errors) && !result.errors.length) ||
+    fetchOptions.errorPolicy === 'all' ||
+    fetchOptions.errorPolicy === 'ignore'
 
   if (response.ok && successfullyPassedErrorPolicy && successfullyReceivedData) {
     const { headers, status } = response

--- a/src/index.ts
+++ b/src/index.ts
@@ -482,7 +482,7 @@ async function makeRequest<T = any, V extends Variables = Variables>({
     isBatchingQuery && Array.isArray(result) ? !result.some(({ data }) => !data) : !!result.data
 
   const successfullyPassedErrorPolicy =
-    !result.errors || fetchOptions.errorPolicy === 'all' || fetchOptions.errorPolicy === 'ignore'
+    !result.errors || !result.errors.length || fetchOptions.errorPolicy === 'all' || fetchOptions.errorPolicy === 'ignore'
 
   if (response.ok && successfullyPassedErrorPolicy && successfullyReceivedData) {
     const { headers, status } = response

--- a/tests/__helpers.ts
+++ b/tests/__helpers.ts
@@ -3,7 +3,7 @@ import body from 'body-parser'
 import express, { Application, Request } from 'express'
 import getPort from 'get-port'
 import { createServer, Server } from 'http'
-import { JsonObject } from 'type-fest'
+import { JsonArray, JsonObject } from 'type-fest'
 import { beforeAll, afterEach, afterAll, beforeEach } from 'vitest'
 
 type CapturedRequest = Pick<Request, 'headers' | 'method' | 'body'>
@@ -21,7 +21,7 @@ type Context<S extends MockSpec | MockSpecBatch = MockSpec> = {
 type MockSpecBody = {
   data?: JsonObject
   extensions?: JsonObject
-  errors?: JsonObject
+  errors?: JsonObject | JsonArray
 }
 
 type MockSpec = {

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -396,3 +396,16 @@ describe('operationName parsing', () => {
     expect(requestBody.operationName).toEqual('myStringOperation')
   })
 })
+
+test('should not throw error when errors property is an empty array (occured when using UltraGraphQL)', async () => {
+  ctx.res({
+    body: {
+      data: { test: 'test' },
+      errors: [],
+    },
+  })
+
+  const res = await new GraphQLClient(ctx.url).request(`{ test }`)
+
+  expect(res).toEqual(expect.objectContaining({ test: 'test' }))
+})


### PR DESCRIPTION
Hello,

We have a project called courses 3 which is a learning management system. In this project, we started using UltraGraphQL as the back end. We have encountered error responses after making correct requests from the front end using the 'request' function from graphql-request. After checking out the error, it seems that the response had no error, but the function evaluated it otherwise. In the next sample, you can see the error which we have printed out from the front end. 

`Error: GraphQL Error (Code: 200): {"response":{"extensions":{},"data":{"courses_User":[{"courses_lastName":["Admin"],"courses_email":["admin@admin.admin"]}],"@context":{"_type":"@type","courses_email":"http://www.courses.matfyz.sk/ontology#email","courses_User":"http://www.courses.matfyz.sk/ontology#User","_id":"@id","courses_lastName":"http://www.courses.matfyz.sk/ontology#lastName"}},"errors":[],"status":200,"headers":{"map":{"content-type":"application/json; charset=utf-8"}}},"request":{"query":"\n                {\n                  courses_User {\n                      courses_email\n                      courses_lastName\n                  }\n                }\n              "}}`

After digging around, I found out that the errors property from the response was an empty Array. This empty array when put in a condition like result.errors returned true. Because of this !result.errors was evaluated false and thus the variable successfullyPassedErrorPolicy at line 484 in src/index.ts was evaluated as false. This meant that the successful response was evaluated as unsuccessful returning ClientError.

I have fixed it by extending the condition by checking if the result.errors is an empty array.   