### PR TITLE
Remove duplicate fragments from resolved request document

### DIFF
--- a/src/resolveRequestDocument.ts
+++ b/src/resolveRequestDocument.ts
@@ -9,7 +9,7 @@ import { parse, print } from 'graphql'
 const dedupFragmentsDefinitions = (document: DocumentNode): DocumentNode => {
   const seen: string[] = []
 
-  const fragmentDefinitions = document.definitions.filter((definition) => {
+  const fragmentsDefinitions = document.definitions.filter((definition) => {
     if (definition.kind !== `FragmentDefinition`) {
       return true
     }
@@ -24,7 +24,7 @@ const dedupFragmentsDefinitions = (document: DocumentNode): DocumentNode => {
 
   return {
     ...document,
-    definitions: fragmentDefinitions,
+    definitions: fragmentsDefinitions,
   }
 }
 


### PR DESCRIPTION
In scenarios where a fragment is nested and used multiple times, `graphql-request` includes the fragments' bodies multiple times.

Use case example: [Unleash the power of Fragments with GraphQL Codegen](https://the-guild.dev/blog/unleash-the-power-of-fragments-with-graphql-codegen)

### Scenario
```js
const FragmentB = gql`
  fragment FragmentB on Other {
    number
  }
`;

const FragmentA = gql`
  fragment FragmentA on Something {
    value
    other {
      ...FragmentB
    }
  }
  ${FragmentB}
`;

const Query = gql`
  query Query {
    a {
      ...FragmentA
    }
    b {
      ...FragmentB
    }
  }
  ${FragmentA}
  ${FragmentB}
`;
```

### Current output
```js
  query Query {
    a {
      ...FragmentA
    }
    b {
      ...FragmentB
    }
  }

  fragment FragmentA on Something {
    value
    other {
      ...FragmentB
    }
  }

  fragment FragmentB on Other {
    number
  }

  fragment FragmentB on Other {
    number
  }
```

### Pull request output
```js
  query Query {
    a {
      ...FragmentA
    }
    b {
      ...FragmentB
    }
  }

  fragment FragmentA on Something {
    value
    other {
      ...FragmentB
    }
  }

  fragment FragmentB on Other {
    number
  }
```