### PR TITLE
chore(docs): regenerate TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
   - [Why do I have to install `graphql`?](#why-do-i-have-to-install-graphql)
   - [Do I need to wrap my GraphQL documents inside the `gql` template exported by `graphql-request`?](#do-i-need-to-wrap-my-graphql-documents-inside-the-gql-template-exported-by-graphql-request)
   - [What sets `graphql-request` apart from other clients like Apollo, Relay, etc.?](#what-sets-graphql-request-apart-from-other-clients-like-apollo-relay-etc)
-  - [Why is the package `main` field missing?](#why-is-the-package-main-field-missing)
-  - [How do I work around React Native + Metro's lack of `exports` support?](#how-do-i-work-around-react-native--metros-lack-of-exports-support)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
This updates the TOC. Seems that for the last PR the `build:docs` script hadn't been run. This PR fixes that and removes the two items no longer present in the readme.

Wrt our conversation here: https://github.com/jasonkuhrt/graphql-request/pull/526#issuecomment-1552453800:

> Can you please update the docs about this topic. Just remove them. Also please make a new issue to remove main once the Metro issue is closed. Thanks!

> Would it be possible to expand that to current tooling that is still using main? I'm still waiting on the resolve package to add support for parsing exports for example.

> yep please create that issue or chime into existing one if there, thanks!

I could not find any follow up issue in this repo for removing main, so I'll consider the matter resolved. I suppose the core takeaway is to not remove main as long as it's still valid for current gen. tooling. 