### PR TITLE
improvement: Optimised imports from graphql to decrease bundle size

### DIFF
--- a/src/resolveRequestDocument.ts
+++ b/src/resolveRequestDocument.ts
@@ -1,6 +1,7 @@
 import type { RequestDocument } from './types.js'
-import type { DocumentNode, OperationDefinitionNode } from 'graphql'
-import { parse, print } from 'graphql'
+import type { DocumentNode, OperationDefinitionNode } from 'graphql/language/ast.js'
+import { parse } from 'graphql/language/parser.js'
+import { print } from 'graphql/language/printer.js'
 
 /**
  * helpers


### PR DESCRIPTION
### Description 
While integrating graphql-request into a project to replace apollo-client, on analyzing the bundles created by webpack, I saw that `graphql` as a dependency itself is taking up a bit more than 500Kib in the chunk generated by webpack. 

One of the major pros towards opting for graphql-request was its minimal bundle size, and with just these more specific imports, we end up saving close to 300KiB directly. Projects with webpack 4 and some legacy packages would be able to have these smaller bundles as well with this minor refactor

### Screenshots

| Before             |  After |
:-------------------------:|:-------------------------:
 ![](https://github.com/jasonkuhrt/graphql-request/assets/44222543/a53403ae-2d4c-41dd-8017-dfa5b8cb18e1) |  ![](https://github.com/jasonkuhrt/graphql-request/assets/44222543/3a7aa607-5cc2-420c-84d8-de9ac65f7639)
