### PR TITLE
feat: export GraphQLClientRequestHeader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -676,6 +676,7 @@ export {
   BatchRequestsOptions,
   ClientError,
   GraphQLClient,
+  GraphQLClientRequestHeaders,
   rawRequest,
   RawRequestExtendedOptions,
   RawRequestOptions,


### PR DESCRIPTION
This type is used in the @graphql-codegen/typescript-graphql-request package.