### PR TITLE
fix: default T to any

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ class GraphQLClient {
   /**
    * Send a GraphQL query to the server.
    */
-  rawRequest: RawRequestMethod = async <T, V extends Variables = Variables>(
+  rawRequest: RawRequestMethod = async <T = any, V extends Variables = Variables>(
     ...args: RawRequestMethodArgs<V>
   ): Promise<GraphQLClientResponse<T>> => {
     const [queryOrOptions, variables, requestHeaders] = args
@@ -240,12 +240,12 @@ class GraphQLClient {
   /**
    * Send a GraphQL document to the server.
    */
-  async request<T extends any, V extends Variables = Variables>(
+  async request<T = any, V extends Variables = Variables>(
     document: RequestDocument | TypedDocumentNode<T, V>,
     ...variablesAndRequestHeaders: VariablesAndRequestHeadersArgs<V>
   ): Promise<T>
-  async request<T extends any, V extends Variables = Variables>(options: RequestOptions<V, T>): Promise<T>
-  async request<T extends any, V extends Variables = Variables>(
+  async request<T = any, V extends Variables = Variables>(options: RequestOptions<V, T>): Promise<T>
+  async request<T = any, V extends Variables = Variables>(
     documentOrOptions: RequestDocument | TypedDocumentNode<T, V> | RequestOptions<V>,
     ...variablesAndRequestHeaders: VariablesAndRequestHeadersArgs<V>
   ): Promise<T> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,12 +240,12 @@ class GraphQLClient {
   /**
    * Send a GraphQL document to the server.
    */
-  async request<T, V extends Variables = Variables>(
+  async request<T extends any, V extends Variables = Variables>(
     document: RequestDocument | TypedDocumentNode<T, V>,
     ...variablesAndRequestHeaders: VariablesAndRequestHeadersArgs<V>
   ): Promise<T>
-  async request<T, V extends Variables = Variables>(options: RequestOptions<V, T>): Promise<T>
-  async request<T, V extends Variables = Variables>(
+  async request<T extends any, V extends Variables = Variables>(options: RequestOptions<V, T>): Promise<T>
+  async request<T extends any, V extends Variables = Variables>(
     documentOrOptions: RequestDocument | TypedDocumentNode<T, V> | RequestOptions<V>,
     ...variablesAndRequestHeaders: VariablesAndRequestHeadersArgs<V>
   ): Promise<T> {


### PR DESCRIPTION
After upgrading to 6.X.X version we saw a regression in our codebase.

The 6 version seems to force `.request` method to provide a type otherwise the method return a type "unknow".

Here i suggest to add a `= any` to let developers to use the `.request` method without any types.

Context: We have a typed client in our code, but our test suites juste use some graphql request with template strings and no response types.