### PR TITLE
chore(ci): update Node.js versions to latest LTS

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18]
+        node: [18, 20]
         environment: [happy-dom, node]
     name: Node ${{ matrix.node }} @env ${{matrix.environment}}
     steps:


### PR DESCRIPTION
Updates the workflow in CI to use the latest long-term support versions of Node.js (v18 & v20).