### PR TITLE
feat!: replace `GraphQLClientRequestHeaders` with built-in `HeadersInit` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import { resolveRequestDocument } from './resolveRequestDocument.js'
 import type {
   BatchRequestDocument,
   FetchOptions,
-  GraphQLClientRequestHeaders,
   GraphQLClientResponse,
   HTTPMethodInput,
   JsonSerializer,
@@ -37,7 +36,7 @@ import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 /**
  * Convert the given headers configuration into a plain object.
  */
-const resolveHeaders = (headers?: GraphQLClientRequestHeaders): Record<string, string> => {
+const resolveHeaders = (headers?: HeadersInit): Record<string, string> => {
   let oHeaders: Record<string, string> = {}
   if (headers) {
     if (headers instanceof Headers) {
@@ -124,7 +123,7 @@ interface RequestVerbParams<V extends Variables = Variables> {
   fetch: Fetch
   fetchOptions: FetchOptions
   variables?: V
-  headers?: GraphQLClientRequestHeaders
+  headers?: HeadersInit
   operationName?: string
   middleware?: RequestMiddleware<V>
 }
@@ -297,11 +296,11 @@ class GraphQLClient {
    * Send GraphQL documents in batch to the server.
    */
   // prettier-ignore
-  batchRequests<T extends BatchResult, V extends Variables = Variables>(documents: BatchRequestDocument<V>[], requestHeaders?: GraphQLClientRequestHeaders): Promise<T>
+  batchRequests<T extends BatchResult, V extends Variables = Variables>(documents: BatchRequestDocument<V>[], requestHeaders?: HeadersInit): Promise<T>
   // prettier-ignore
   batchRequests<T extends BatchResult, V extends Variables = Variables>(options: BatchRequestsOptions<V>): Promise<T>
   // prettier-ignore
-  batchRequests<T extends BatchResult, V extends Variables = Variables>(documentsOrOptions: BatchRequestDocument<V>[] | BatchRequestsOptions<V>, requestHeaders?: GraphQLClientRequestHeaders): Promise<T> {
+  batchRequests<T extends BatchResult, V extends Variables = Variables>(documentsOrOptions: BatchRequestDocument<V>[] | BatchRequestsOptions<V>, requestHeaders?: HeadersInit): Promise<T> {
     const batchRequestOptions = parseBatchRequestArgs<V>(documentsOrOptions, requestHeaders)
     const { headers, ...fetchOptions } = this.requestConfig
 
@@ -343,7 +342,7 @@ class GraphQLClient {
       })
   }
 
-  setHeaders(headers: GraphQLClientRequestHeaders): GraphQLClient {
+  setHeaders(headers: HeadersInit): GraphQLClient {
     this.requestConfig.headers = headers
     return this
   }
@@ -378,7 +377,7 @@ const makeRequest = async <T = unknown, V extends Variables = Variables>(params:
   url: string
   query: string | string[]
   variables?: V
-  headers?: GraphQLClientRequestHeaders
+  headers?: HeadersInit
   operationName?: string
   fetch: Fetch
   method?: HTTPMethodInput
@@ -431,13 +430,13 @@ const makeRequest = async <T = unknown, V extends Variables = Variables>(params:
 
 // prettier-ignore
 interface RawRequestMethod {
-  <T, V extends Variables = Variables>(query: string, variables?: V, requestHeaders?: GraphQLClientRequestHeaders): Promise<GraphQLClientResponse<T>>
+  <T, V extends Variables = Variables>(query: string, variables?: V, requestHeaders?: HeadersInit): Promise<GraphQLClientResponse<T>>
   <T, V extends Variables = Variables>(options: RawRequestOptions<V>): Promise<GraphQLClientResponse<T>>
 }
 
 // prettier-ignore
 type RawRequestMethodArgs<V extends Variables> =
-  | [query: string, variables?: V, requestHeaders?: GraphQLClientRequestHeaders]
+  | [query: string, variables?: V, requestHeaders?: HeadersInit]
   | [RawRequestOptions<V>]
 
 // prettier-ignore
@@ -563,12 +562,12 @@ type BatchResult = [Result, ...Result[]]
 
 // prettier-ignore
 interface BatchRequests {
-  <T extends BatchResult, V extends Variables = Variables>(url: string, documents: BatchRequestDocument<V>[], requestHeaders?: GraphQLClientRequestHeaders): Promise<T>
+  <T extends BatchResult, V extends Variables = Variables>(url: string, documents: BatchRequestDocument<V>[], requestHeaders?: HeadersInit): Promise<T>
   <T extends BatchResult, V extends Variables = Variables>(options: BatchRequestsExtendedOptions<V>): Promise<T>
 }
 
 type BatchRequestsArgs =
-  | [url: string, documents: BatchRequestDocument[], requestHeaders?: GraphQLClientRequestHeaders]
+  | [url: string, documents: BatchRequestDocument[], requestHeaders?: HeadersInit]
   | [options: BatchRequestsExtendedOptions]
 
 const parseBatchRequestsArgsExtended = (args: BatchRequestsArgs): BatchRequestsExtendedOptions => {
@@ -674,7 +673,6 @@ export {
   BatchRequestsOptions,
   ClientError,
   GraphQLClient,
-  GraphQLClientRequestHeaders,
   rawRequest,
   RawRequestExtendedOptions,
   RawRequestOptions,

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -1,7 +1,6 @@
 import type {
   BatchRequestDocument,
   BatchRequestsOptions,
-  GraphQLClientRequestHeaders,
   RawRequestExtendedOptions,
   RawRequestOptions,
   RequestDocument,
@@ -14,7 +13,7 @@ import type {
 export const parseRequestArgs = <V extends Variables = Variables>(
   documentOrOptions: RequestDocument | RequestOptions<V>,
   variables?: V,
-  requestHeaders?: GraphQLClientRequestHeaders,
+  requestHeaders?: HeadersInit,
 ): RequestOptions<V> => {
   return (documentOrOptions as RequestOptions<V>).document
     ? (documentOrOptions as RequestOptions<V>)
@@ -29,7 +28,7 @@ export const parseRequestArgs = <V extends Variables = Variables>(
 export const parseRawRequestArgs = <V extends Variables = Variables>(
   queryOrOptions: string | RawRequestOptions<V>,
   variables?: V,
-  requestHeaders?: GraphQLClientRequestHeaders,
+  requestHeaders?: HeadersInit,
 ): RawRequestOptions<V> => {
   return (queryOrOptions as RawRequestOptions<V>).query
     ? (queryOrOptions as RawRequestOptions<V>)
@@ -43,7 +42,7 @@ export const parseRawRequestArgs = <V extends Variables = Variables>(
 
 export const parseBatchRequestArgs = <V extends Variables = Variables>(
   documentsOrOptions: BatchRequestDocument<V>[] | BatchRequestsOptions<V>,
-  requestHeaders?: GraphQLClientRequestHeaders,
+  requestHeaders?: HeadersInit,
 ): BatchRequestsOptions<V> => {
   return (documentsOrOptions as BatchRequestsOptions<V>).documents
     ? (documentsOrOptions as BatchRequestsOptions<V>)

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export type HTTPMethodInput = 'GET' | 'POST' | 'get' | 'post'
 export interface RequestConfig extends Omit<RequestInit, 'headers' | 'method'>, AdditionalRequestOptions {
   fetch?: Fetch
   method?: HTTPMethodInput
-  headers?: MaybeLazy<GraphQLClientRequestHeaders>
+  headers?: MaybeLazy<HeadersInit>
   requestMiddleware?: RequestMiddleware
   responseMiddleware?: ResponseMiddleware
   jsonSerializer?: JsonSerializer
@@ -106,7 +106,7 @@ export type BatchRequestDocument<V extends Variables = Variables> = {
 
 export type RawRequestOptions<V extends Variables = Variables> = {
   query: string
-  requestHeaders?: GraphQLClientRequestHeaders
+  requestHeaders?: HeadersInit
   signal?: RequestInit['signal']
 } & (V extends Record<any, never>
   ? { variables?: V }
@@ -116,7 +116,7 @@ export type RawRequestOptions<V extends Variables = Variables> = {
 
 export type RequestOptions<V extends Variables = Variables, T = unknown> = {
   document: RequestDocument | TypedDocumentNode<T, V>
-  requestHeaders?: GraphQLClientRequestHeaders
+  requestHeaders?: HeadersInit
   signal?: RequestInit['signal']
 } & (V extends Record<any, never>
   ? { variables?: V }
@@ -126,7 +126,7 @@ export type RequestOptions<V extends Variables = Variables, T = unknown> = {
 
 export interface BatchRequestsOptions<V extends Variables = Variables> {
   documents: BatchRequestDocument<V>[]
-  requestHeaders?: GraphQLClientRequestHeaders
+  requestHeaders?: HeadersInit
   signal?: RequestInit['signal']
 }
 
@@ -154,14 +154,10 @@ type RequestExtendedInit<V extends Variables = Variables> = RequestInit & {
   variables?: V
 }
 
-// TODO: Replace this type with the built-in `HeadersInit` type.
-// See: https://github.com/jasonkuhrt/graphql-request/issues/608
-export type GraphQLClientRequestHeaders = Headers | string[][] | Record<string, string>
-
 // prettier-ignore
 export type VariablesAndRequestHeadersArgs<V extends Variables> =
   V extends Record<any, never> // do we have explicitly no variables allowed?
-    ? [variables?: V, requestHeaders?: GraphQLClientRequestHeaders]
+    ? [variables?: V, requestHeaders?: HeadersInit]
   : keyof RemoveIndex<V> extends never // do we get an empty variables object?
-    ? [variables?: V, requestHeaders?: GraphQLClientRequestHeaders]
-    : [variables: V, requestHeaders?: GraphQLClientRequestHeaders]
+    ? [variables?: V, requestHeaders?: HeadersInit]
+    : [variables: V, requestHeaders?: HeadersInit]

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -38,7 +38,7 @@ describe(`using class`, () => {
   })
 
   describe(`custom header in the request`, () => {
-    describe.each([
+    describe.each<HeadersInit[]>([
       [new Headers({ 'x-request-foo': `request-bar` })],
       [{ 'x-request-foo': `request-bar` }],
       [[[`x-request-foo`, `request-bar`]]],
@@ -66,7 +66,7 @@ describe(`using class`, () => {
       })
     })
 
-    describe.each([
+    describe.each<HeadersInit[]>([
       [new Headers({ 'x-foo': `request-bar` })],
       [{ 'x-foo': `request-bar` }],
       [[[`x-foo`, `request-bar`]]],
@@ -129,7 +129,7 @@ describe(`using class`, () => {
 })
 
 describe(`using request function`, () => {
-  describe.each([
+  describe.each<HeadersInit[]>([
     [new Headers({ 'x-request-foo': `request-bar` })],
     [{ 'x-request-foo': `request-bar` }],
     [[[`x-request-foo`, `request-bar`]]],


### PR DESCRIPTION
Closes #608