### PR TITLE
feat!: add spec compliant default `Accept` header

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export const ACCEPT_HEADER = `Accept`
+export const CONTENT_TYPE_HEADER = `Content-Type`
+export const CONTENT_TYPE_JSON = `application/json`
+export const CONTENT_TYPE_GQL = `application/graphql-response+json`

--- a/tests/__snapshots__/document-node.test.ts.snap
+++ b/tests/__snapshots__/document-node.test.ts.snap
@@ -12,7 +12,7 @@ exports[`accepts graphql DocumentNode as alternative to raw string 1`] = `
 }",
       },
       "headers": {
-        "accept": "*/*",
+        "accept": "application/graphql-response+json, application/json",
         "accept-encoding": "gzip, deflate",
         "accept-language": "*",
         "connection": "keep-alive",

--- a/tests/__snapshots__/gql.test.ts.snap
+++ b/tests/__snapshots__/gql.test.ts.snap
@@ -11,7 +11,7 @@ exports[`gql > passthrough allowing benefits of tooling for gql template tag 1`]
 }",
       },
       "headers": {
-        "accept": "*/*",
+        "accept": "application/graphql-response+json, application/json",
         "accept-encoding": "gzip, deflate",
         "accept-language": "*",
         "connection": "keep-alive",

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -107,24 +107,6 @@ describe(`using class`, () => {
         expect(mock.requests[0]?.headers[`x-foo`]).toEqual(`new`)
       })
     })
-
-    describe(`allows content-type header to be overwritten`, () => {
-      test(`with request method`, async () => {
-        const headers = new Headers({ 'content-type': `text/plain` })
-        const client = new GraphQLClient(ctx.url, { headers })
-        const mock = ctx.res()
-        await client.request(`{ me { id } }`)
-        expect(mock.requests[0]?.headers[`content-type`]).toEqual(`text/plain`)
-      })
-
-      test(`with rawRequest method`, async () => {
-        const headers = new Headers({ 'content-type': `text/plain` })
-        const client = new GraphQLClient(ctx.url, { headers })
-        const mock = ctx.res()
-        await client.rawRequest(`{ me { id } }`)
-        expect(mock.requests[0]?.headers[`content-type`]).toEqual(`text/plain`)
-      })
-    })
   })
 })
 


### PR DESCRIPTION
Adds the `Accept` header to all requests with a [spec-compliant mime-type](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#accept). This PR also does some code cleanup and removes support for the legacy `application/graphql+json` mime type.

Closes #140