### PR TITLE
feat(ts-client): string support for custom scalars

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
         "types": "./build/entrypoints/alpha/schema.d.ts",
         "default": "./build/entrypoints/alpha/schema.js"
       }
+    },
+    "./alpha/schema/scalars": {
+      "import": {
+        "types": "./build/entrypoints/alpha/scalars.d.ts",
+        "default": "./build/entrypoints/alpha/scalars.js"
+      }
     }
   },
   "packageManager": "pnpm@8.15.5",

--- a/src/ResultSet/ResultSet.test-d.ts
+++ b/src/ResultSet/ResultSet.test-d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { expectTypeOf, test } from 'vitest'
-import type * as Schema from '../../tests/ts/_/schema.js'
+import type * as Schema from '../../tests/ts/_/schema/Schema.js'
 import type { SelectionSet } from '../SelectionSet/__.js'
 import type { ResultSet } from './__.js'
 
@@ -22,6 +22,9 @@ test(`general`, () => {
   expectTypeOf<RS<{ id: true; string: false }>>().toEqualTypeOf<{ id: null | string }>()
   expectTypeOf<RS<{ id: true; string: 0 }>>().toEqualTypeOf<{ id: null | string }>()
   expectTypeOf<RS<{ id: true; string: undefined }>>().toEqualTypeOf<{ id: null | string }>()
+  
+  // Custom Scalar
+  expectTypeOf<RS<{ date: true }>>().toEqualTypeOf<{ date: null | string }>()
 
   // List
   expectTypeOf<RS<{ listIntNonNull: true }>>().toEqualTypeOf<{ listIntNonNull: number[] }>()

--- a/src/Schema/Index.ts
+++ b/src/Schema/Index.ts
@@ -12,5 +12,4 @@ export interface Index {
   unions: {
     Union: null | Union
   }
-  scalars: object
 }

--- a/src/Schema/NamedType/Scalar/Scalar.ts
+++ b/src/Schema/NamedType/Scalar/Scalar.ts
@@ -2,6 +2,8 @@
 
 import { nativeScalarConstructors } from './nativeConstructors.js'
 
+export { nativeScalarConstructors } from './nativeConstructors.js'
+
 export const ScalarKind = `Scalar`
 
 export type ScalarKind = typeof ScalarKind
@@ -44,4 +46,17 @@ export type Boolean = typeof Boolean
 
 export type Float = typeof Float
 
-export type Any = String | Int | Boolean | ID | Float
+export const Scalars = {
+  String,
+  ID,
+  Int,
+  Float,
+  Boolean,
+}
+
+// eslint-disable-next-line
+export type Any = String | Int | Boolean | ID | Float | SchemaCustomScalars[keyof SchemaCustomScalars]
+
+declare global {
+  interface SchemaCustomScalars {}
+}

--- a/src/SelectionSet/SelectionSet.test-d.ts
+++ b/src/SelectionSet/SelectionSet.test-d.ts
@@ -1,5 +1,5 @@
 import { assertType, expectTypeOf, test } from 'vitest'
-import type * as Schema from '../../tests/ts/_/schema.js'
+import type * as Schema from '../../tests/ts/_/schema/Schema.js'
 import type { SelectionSet } from './__.js'
 
 type Q = SelectionSet.Query<Schema.$.Index>
@@ -28,6 +28,13 @@ test(`Query`, () => {
   assertType<Q>({ id: undefined })
   // non-null
   assertType<Q>({ idNonNull: true })
+
+  // Custom Scalar
+  assertType<Q>({ date: true })
+  assertType<Q>({ date: false })
+  assertType<Q>({ date: 0 })
+  assertType<Q>({ date: 1 })
+  assertType<Q>({ date: undefined })
 
   // Enum
   assertType<Q>({ abcEnum: true })

--- a/src/SelectionSet/toGraphQLDocumentString.test.ts
+++ b/src/SelectionSet/toGraphQLDocumentString.test.ts
@@ -1,6 +1,6 @@
 import { parse, print } from 'graphql'
 import { describe, expect, test } from 'vitest'
-import type * as Schema from '../../tests/ts/_/schema.js'
+import type * as Schema from '../../tests/ts/_/schema/Schema.js'
 import type { SelectionSet } from './__.js'
 import { toGraphQLDocumentString } from './toGraphQLDocumentString.js'
 

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -9,8 +9,8 @@ const args = Command.create().description(`Generate a type safe GraphQL client.`
   .parameter(`schema`, z.string().min(1).describe(`File path to where your GraphQL schema is.`))
   .parameter(
     `output`,
-    z.string().min(1).optional().describe(
-      `File path for where to output the generated TypeScript types. If not given, outputs to stdout.`,
+    z.string().min(1).describe(
+      `Directory path for where to output the generated TypeScript files.`,
     ),
   )
   .settings({
@@ -23,8 +23,5 @@ const args = Command.create().description(`Generate a type safe GraphQL client.`
 const schemaSource = await fs.readFile(args.schema, `utf8`)
 const code = generateCode({ schemaSource })
 
-if (args.output) {
-  await fs.writeFile(args.output, code, { encoding: `utf8` })
-} else {
-  console.log(code)
-}
+await fs.writeFile(`${args.output}/schema.ts`, code.schema, { encoding: `utf8` })
+await fs.writeFile(`${args.output}/scalars.ts`, code.scalars, { encoding: `utf8` })

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { setupMockServer } from '../tests/raw/__helpers.js'
-import type { $ } from '../tests/ts/_/schema.js'
+import type { $ } from '../tests/ts/_/schema/Schema.js'
 import { create } from './client.js'
 
 const ctx = setupMockServer()

--- a/src/entrypoints/alpha/scalars.ts
+++ b/src/entrypoints/alpha/scalars.ts
@@ -1,0 +1,1 @@
+export * from '../../Schema/NamedType/Scalar/Scalar.js'

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -15,6 +15,15 @@ export type TypeMapByKind =
     [Name in keyof NameToClassNamedType]: InstanceType<NameToClassNamedType[Name]>[]
   }
   & { GraphQLRootTypes: GraphQLObjectType<any, any>[] }
+  & { GraphQLCustomScalarType: GraphQLScalarType<any, any>[] }
+
+const scalarTypeNames = {
+  String: `String`,
+  ID: `ID`,
+  Int: `Int`,
+  Float: `Float`,
+  Boolean: `Boolean`,
+}
 
 export const getTypeMapByKind = (schema: GraphQLSchema) => {
   const typeMap = schema.getTypeMap()
@@ -22,6 +31,7 @@ export const getTypeMapByKind = (schema: GraphQLSchema) => {
   const typeMapByKind: TypeMapByKind = {
     GraphQLRootTypes: [],
     GraphQLScalarType: [],
+    GraphQLCustomScalarType: [],
     GraphQLEnumType: [],
     GraphQLInputObjectType: [],
     GraphQLInterfaceType: [],
@@ -33,6 +43,9 @@ export const getTypeMapByKind = (schema: GraphQLSchema) => {
     switch (true) {
       case type instanceof GraphQLScalarType:
         typeMapByKind.GraphQLScalarType.push(type)
+        if (!(type.name in scalarTypeNames)) {
+          typeMapByKind.GraphQLCustomScalarType.push(type)
+        }
         break
       case type instanceof GraphQLEnumType:
         typeMapByKind.GraphQLEnumType.push(type)

--- a/src/raw/lib/graphql.ts
+++ b/src/raw/lib/graphql.ts
@@ -35,7 +35,7 @@ export const parseGraphQLExecutionResult = (result: unknown): Error | GraphQLReq
   try {
     if (Array.isArray(result)) {
       return {
-        _tag: `Batch` as const,
+        _tag: `Batch`,
         executionResults: result.map(parseExecutionResult),
       }
     } else if (isPlainObject(result)) {

--- a/src/raw/lib/graphql.ts
+++ b/src/raw/lib/graphql.ts
@@ -53,7 +53,7 @@ export const parseGraphQLExecutionResult = (result: unknown): Error | GraphQLReq
 
 /**
  * Example result:
- * 
+ *
  * ```
  * {
  *  "data": null,
@@ -62,7 +62,7 @@ export const parseGraphQLExecutionResult = (result: unknown): Error | GraphQLReq
  *    "locations": [{ "line": 2, "column": 3 }],
  *    "path": ["playerNew"]
  *  }]
- *}
+ * }
  * ```
  */
 export const parseExecutionResult = (result: unknown): GraphQLExecutionResultSingle => {
@@ -75,13 +75,17 @@ export const parseExecutionResult = (result: unknown): GraphQLExecutionResultSin
   let extensions = undefined
 
   if (`errors` in result) {
-    if (!isPlainObject(result.errors) && !Array.isArray(result.errors)) throw new Error(`Invalid execution result: errors is not plain object OR array`) // prettier-ignore
+    if (!isPlainObject(result.errors) && !Array.isArray(result.errors)) {
+      throw new Error(`Invalid execution result: errors is not plain object OR array`) // prettier-ignore
+    }
     errors = result.errors
   }
 
   // todo add test coverage for case of null. @see https://github.com/jasonkuhrt/graphql-request/issues/739
   if (`data` in result) {
-    if (!isPlainObject(result.data) && result.data !== null) throw new Error(`Invalid execution result: data is not plain object`) // prettier-ignore
+    if (!isPlainObject(result.data) && result.data !== null) {
+      throw new Error(`Invalid execution result: data is not plain object`) // prettier-ignore
+    }
     data = result.data
   }
 

--- a/tests/ts/_/schema.graphql
+++ b/tests/ts/_/schema.graphql
@@ -1,4 +1,7 @@
+scalar Date
+
 type Query {
+	date: Date
 	interface: Interface
 	id: ID
 	idNonNull: ID!

--- a/tests/ts/_/schema/Scalar.ts
+++ b/tests/ts/_/schema/Scalar.ts
@@ -1,0 +1,12 @@
+import * as Scalar from '../../../../src/Schema/NamedType/Scalar/Scalar.js'
+
+declare global {
+  interface SchemaCustomScalars {
+    Date: Date
+  }
+}
+
+export const Date = Scalar.scalar(`Date`, Scalar.nativeScalarConstructors.String)
+export type Date = typeof Date
+
+export * from '../../../../src/Schema/NamedType/Scalar/Scalar.js'

--- a/tests/ts/_/schema/Schema.ts
+++ b/tests/ts/_/schema/Schema.ts
@@ -1,4 +1,5 @@
-import type * as _ from '../../../src/Schema/__.js'
+import type * as _ from '../../../../src/Schema/__.js'
+import type * as $Scalar from './Scalar.ts'
 
 export namespace $ {
   export interface Index {
@@ -22,14 +23,6 @@ export namespace $ {
         | Union.FooBarUnion
         | Union.lowerCaseUnion
     }
-    scalars: Scalars
-  }
-  export interface Scalars {
-    ID: string
-    String: string
-    Int: number
-    Float: number
-    Boolean: boolean
   }
 }
 
@@ -39,73 +32,74 @@ export namespace $ {
 
 export namespace Root {
   export type Query = _.Object<'Query', {
+    date: _.Field<_.Output.Nullable<$Scalar.Date>>
     interface: _.Field<_.Output.Nullable<Interface.Interface>>
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
-    idNonNull: _.Field<_.Scalar.ID>
-    string: _.Field<_.Output.Nullable<_.Scalar.String>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
+    idNonNull: _.Field<$Scalar.ID>
+    string: _.Field<_.Output.Nullable<$Scalar.String>>
     stringWithRequiredArg: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
-        string: _.Scalar.String
+        string: $Scalar.String
       }>
     >
     stringWithArgs: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
-        string: _.Input.Nullable<_.Scalar.String>
-        int: _.Input.Nullable<_.Scalar.Int>
-        float: _.Input.Nullable<_.Scalar.Float>
-        boolean: _.Input.Nullable<_.Scalar.Boolean>
-        id: _.Input.Nullable<_.Scalar.ID>
+        string: _.Input.Nullable<$Scalar.String>
+        int: _.Input.Nullable<$Scalar.Int>
+        float: _.Input.Nullable<$Scalar.Float>
+        boolean: _.Input.Nullable<$Scalar.Boolean>
+        id: _.Input.Nullable<$Scalar.ID>
       }>
     >
     stringWithArgEnum: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
         ABCEnum: _.Input.Nullable<Enum.ABCEnum>
       }>
     >
     stringWithListArg: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
-        ints: _.Input.Nullable<_.Input.List<_.Input.Nullable<_.Scalar.Int>>>
+        ints: _.Input.Nullable<_.Input.List<_.Input.Nullable<$Scalar.Int>>>
       }>
     >
     stringWithListArgRequired: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
-        ints: _.Input.List<_.Input.Nullable<_.Scalar.Int>>
+        ints: _.Input.List<_.Input.Nullable<$Scalar.Int>>
       }>
     >
     stringWithArgInputObject: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
         input: _.Input.Nullable<InputObject.InputObject>
       }>
     >
     stringWithArgInputObjectRequired: _.Field<
-      _.Output.Nullable<_.Scalar.String>,
+      _.Output.Nullable<$Scalar.String>,
       _.Args<{
         input: InputObject.InputObject
       }>
     >
     object: _.Field<_.Output.Nullable<Object.Object>>
-    listListIntNonNull: _.Field<_.Output.List<_.Output.List<_.Scalar.Int>>>
+    listListIntNonNull: _.Field<_.Output.List<_.Output.List<$Scalar.Int>>>
     listListInt: _.Field<
-      _.Output.Nullable<_.Output.List<_.Output.Nullable<_.Output.List<_.Output.Nullable<_.Scalar.Int>>>>>
+      _.Output.Nullable<_.Output.List<_.Output.Nullable<_.Output.List<_.Output.Nullable<$Scalar.Int>>>>>
     >
-    listInt: _.Field<_.Output.Nullable<_.Output.List<_.Output.Nullable<_.Scalar.Int>>>>
-    listIntNonNull: _.Field<_.Output.List<_.Scalar.Int>>
+    listInt: _.Field<_.Output.Nullable<_.Output.List<_.Output.Nullable<$Scalar.Int>>>>
+    listIntNonNull: _.Field<_.Output.List<$Scalar.Int>>
     objectNested: _.Field<_.Output.Nullable<Object.ObjectNested>>
     objectNonNull: _.Field<Object.Object>
     objectWithArgs: _.Field<
       _.Output.Nullable<Object.Object>,
       _.Args<{
-        string: _.Input.Nullable<_.Scalar.String>
-        int: _.Input.Nullable<_.Scalar.Int>
-        float: _.Input.Nullable<_.Scalar.Float>
-        boolean: _.Input.Nullable<_.Scalar.Boolean>
-        id: _.Input.Nullable<_.Scalar.ID>
+        string: _.Input.Nullable<$Scalar.String>
+        int: _.Input.Nullable<$Scalar.Int>
+        float: _.Input.Nullable<$Scalar.Float>
+        boolean: _.Input.Nullable<$Scalar.Boolean>
+        id: _.Input.Nullable<$Scalar.ID>
       }>
     >
     fooBarUnion: _.Field<_.Output.Nullable<Union.FooBarUnion>>
@@ -139,8 +133,8 @@ export namespace Enum {
 
 export namespace InputObject {
   export type InputObject = _.InputObject<'InputObject', {
-    id: _.Input.Nullable<_.Scalar.ID>
-    idRequired: _.Scalar.ID
+    id: _.Input.Nullable<$Scalar.ID>
+    idRequired: $Scalar.ID
   }>
 }
 
@@ -150,7 +144,7 @@ export namespace InputObject {
 
 export namespace Interface {
   export type Interface = _.Interface<'Interface', {
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
   }, [Object.Object1ImplementingInterface, Object.Object2ImplementingInterface]>
 }
 
@@ -168,42 +162,42 @@ export namespace Object {
      *
      * @deprecated Field a is deprecated.
      */
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
   }>
 
   export type Bar = _.Object<'Bar', {
-    int: _.Field<_.Output.Nullable<_.Scalar.Int>>
+    int: _.Field<_.Output.Nullable<$Scalar.Int>>
   }>
 
   export type ObjectNested = _.Object<'ObjectNested', {
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
     object: _.Field<_.Output.Nullable<Object.Object>>
   }>
 
   export type lowerCaseObject = _.Object<'lowerCaseObject', {
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
   }>
 
   export type lowerCaseObject2 = _.Object<'lowerCaseObject2', {
-    int: _.Field<_.Output.Nullable<_.Scalar.Int>>
+    int: _.Field<_.Output.Nullable<$Scalar.Int>>
   }>
 
   export type Object = _.Object<'Object', {
-    string: _.Field<_.Output.Nullable<_.Scalar.String>>
-    int: _.Field<_.Output.Nullable<_.Scalar.Int>>
-    float: _.Field<_.Output.Nullable<_.Scalar.Float>>
-    boolean: _.Field<_.Output.Nullable<_.Scalar.Boolean>>
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+    string: _.Field<_.Output.Nullable<$Scalar.String>>
+    int: _.Field<_.Output.Nullable<$Scalar.Int>>
+    float: _.Field<_.Output.Nullable<$Scalar.Float>>
+    boolean: _.Field<_.Output.Nullable<$Scalar.Boolean>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
   }>
 
   export type Object1ImplementingInterface = _.Object<'Object1ImplementingInterface', {
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
-    int: _.Field<_.Output.Nullable<_.Scalar.Int>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
+    int: _.Field<_.Output.Nullable<$Scalar.Int>>
   }>
 
   export type Object2ImplementingInterface = _.Object<'Object2ImplementingInterface', {
-    id: _.Field<_.Output.Nullable<_.Scalar.ID>>
-    boolean: _.Field<_.Output.Nullable<_.Scalar.Boolean>>
+    id: _.Field<_.Output.Nullable<$Scalar.ID>>
+    boolean: _.Field<_.Output.Nullable<$Scalar.Boolean>>
   }>
 }
 

--- a/tests/ts/__snapshots__/generate.test.ts.snap
+++ b/tests/ts/__snapshots__/generate.test.ts.snap
@@ -1,7 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`generates types from GraphQL SDL file 1`] = `
-"import type * as _ from "../../../src/Schema/__.js"
+"import type * as _ from "../../../../src/Schema/__.js"
+import type * as $Scalar from './Scalar.ts'
+
 
 export namespace $ {
 export interface Index {
@@ -24,14 +26,6 @@ unions: {
 Union: Union.FooBarUnion
 | Union.lowerCaseUnion
 }
-scalars: Scalars
-}
-export interface Scalars {
-ID: string
-String: string
-Int: number
-Float: number
-Boolean: boolean
 }
 }
 
@@ -41,48 +35,49 @@ Boolean: boolean
 
 export namespace Root {
 export type Query = _.Object<"Query", {
+date: _.Field<_.Output.Nullable<$Scalar.Date>>
 interface: _.Field<_.Output.Nullable<Interface.Interface>>
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
-idNonNull: _.Field<_.Scalar.ID>
-string: _.Field<_.Output.Nullable<_.Scalar.String>>
-stringWithRequiredArg: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
-string: _.Scalar.String
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
+idNonNull: _.Field<$Scalar.ID>
+string: _.Field<_.Output.Nullable<$Scalar.String>>
+stringWithRequiredArg: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
+string: $Scalar.String
 }>>
-stringWithArgs: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
-string: _.Input.Nullable<_.Scalar.String>
-int: _.Input.Nullable<_.Scalar.Int>
-float: _.Input.Nullable<_.Scalar.Float>
-boolean: _.Input.Nullable<_.Scalar.Boolean>
-id: _.Input.Nullable<_.Scalar.ID>
+stringWithArgs: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
+string: _.Input.Nullable<$Scalar.String>
+int: _.Input.Nullable<$Scalar.Int>
+float: _.Input.Nullable<$Scalar.Float>
+boolean: _.Input.Nullable<$Scalar.Boolean>
+id: _.Input.Nullable<$Scalar.ID>
 }>>
-stringWithArgEnum: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
+stringWithArgEnum: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
 ABCEnum: _.Input.Nullable<Enum.ABCEnum>
 }>>
-stringWithListArg: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
-ints: _.Input.Nullable<_.Input.List<_.Input.Nullable<_.Scalar.Int>>>
+stringWithListArg: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
+ints: _.Input.Nullable<_.Input.List<_.Input.Nullable<$Scalar.Int>>>
 }>>
-stringWithListArgRequired: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
-ints: _.Input.List<_.Input.Nullable<_.Scalar.Int>>
+stringWithListArgRequired: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
+ints: _.Input.List<_.Input.Nullable<$Scalar.Int>>
 }>>
-stringWithArgInputObject: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
+stringWithArgInputObject: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
 input: _.Input.Nullable<InputObject.InputObject>
 }>>
-stringWithArgInputObjectRequired: _.Field<_.Output.Nullable<_.Scalar.String>, _.Args<{
+stringWithArgInputObjectRequired: _.Field<_.Output.Nullable<$Scalar.String>, _.Args<{
 input: InputObject.InputObject
 }>>
 object: _.Field<_.Output.Nullable<Object.Object>>
-listListIntNonNull: _.Field<_.Output.List<_.Output.List<_.Scalar.Int>>>
-listListInt: _.Field<_.Output.Nullable<_.Output.List<_.Output.Nullable<_.Output.List<_.Output.Nullable<_.Scalar.Int>>>>>>
-listInt: _.Field<_.Output.Nullable<_.Output.List<_.Output.Nullable<_.Scalar.Int>>>>
-listIntNonNull: _.Field<_.Output.List<_.Scalar.Int>>
+listListIntNonNull: _.Field<_.Output.List<_.Output.List<$Scalar.Int>>>
+listListInt: _.Field<_.Output.Nullable<_.Output.List<_.Output.Nullable<_.Output.List<_.Output.Nullable<$Scalar.Int>>>>>>
+listInt: _.Field<_.Output.Nullable<_.Output.List<_.Output.Nullable<$Scalar.Int>>>>
+listIntNonNull: _.Field<_.Output.List<$Scalar.Int>>
 objectNested: _.Field<_.Output.Nullable<Object.ObjectNested>>
 objectNonNull: _.Field<Object.Object>
 objectWithArgs: _.Field<_.Output.Nullable<Object.Object>, _.Args<{
-string: _.Input.Nullable<_.Scalar.String>
-int: _.Input.Nullable<_.Scalar.Int>
-float: _.Input.Nullable<_.Scalar.Float>
-boolean: _.Input.Nullable<_.Scalar.Boolean>
-id: _.Input.Nullable<_.Scalar.ID>
+string: _.Input.Nullable<$Scalar.String>
+int: _.Input.Nullable<$Scalar.Int>
+float: _.Input.Nullable<$Scalar.Float>
+boolean: _.Input.Nullable<$Scalar.Boolean>
+id: _.Input.Nullable<$Scalar.ID>
 }>>
 fooBarUnion: _.Field<_.Output.Nullable<Union.FooBarUnion>>
 /**
@@ -115,8 +110,8 @@ export type ABCEnum = _.Enum<"ABCEnum", ["A", "B", "C"] >
 
 export namespace InputObject {
 export type InputObject = _.InputObject<"InputObject", {
-id: _.Input.Nullable<_.Scalar.ID>
-idRequired: _.Scalar.ID
+id: _.Input.Nullable<$Scalar.ID>
+idRequired: $Scalar.ID
 }>
 }
 
@@ -126,7 +121,7 @@ idRequired: _.Scalar.ID
 
 export namespace Interface {
 export type Interface = _.Interface<"Interface", {
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
 }, [Object.Object1ImplementingInterface, Object.Object2ImplementingInterface]>
 }
 
@@ -144,42 +139,42 @@ export type Foo = _.Object<"Foo", {
 * 
 * @deprecated Field a is deprecated.
 */
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
 }>
 
 export type Bar = _.Object<"Bar", {
-int: _.Field<_.Output.Nullable<_.Scalar.Int>>
+int: _.Field<_.Output.Nullable<$Scalar.Int>>
 }>
 
 export type ObjectNested = _.Object<"ObjectNested", {
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
 object: _.Field<_.Output.Nullable<Object.Object>>
 }>
 
 export type lowerCaseObject = _.Object<"lowerCaseObject", {
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
 }>
 
 export type lowerCaseObject2 = _.Object<"lowerCaseObject2", {
-int: _.Field<_.Output.Nullable<_.Scalar.Int>>
+int: _.Field<_.Output.Nullable<$Scalar.Int>>
 }>
 
 export type Object = _.Object<"Object", {
-string: _.Field<_.Output.Nullable<_.Scalar.String>>
-int: _.Field<_.Output.Nullable<_.Scalar.Int>>
-float: _.Field<_.Output.Nullable<_.Scalar.Float>>
-boolean: _.Field<_.Output.Nullable<_.Scalar.Boolean>>
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
+string: _.Field<_.Output.Nullable<$Scalar.String>>
+int: _.Field<_.Output.Nullable<$Scalar.Int>>
+float: _.Field<_.Output.Nullable<$Scalar.Float>>
+boolean: _.Field<_.Output.Nullable<$Scalar.Boolean>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
 }>
 
 export type Object1ImplementingInterface = _.Object<"Object1ImplementingInterface", {
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
-int: _.Field<_.Output.Nullable<_.Scalar.Int>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
+int: _.Field<_.Output.Nullable<$Scalar.Int>>
 }>
 
 export type Object2ImplementingInterface = _.Object<"Object2ImplementingInterface", {
-id: _.Field<_.Output.Nullable<_.Scalar.ID>>
-boolean: _.Field<_.Output.Nullable<_.Scalar.Boolean>>
+id: _.Field<_.Output.Nullable<$Scalar.ID>>
+boolean: _.Field<_.Output.Nullable<$Scalar.Boolean>>
 }>
 }
 
@@ -195,4 +190,25 @@ export type FooBarUnion = _.Union<"FooBarUnion",[Object.Foo, Object.Bar]>
 
 export type lowerCaseUnion = _.Union<"lowerCaseUnion",[Object.lowerCaseObject, Object.lowerCaseObject2]>
 }"
+`;
+
+exports[`generates types from GraphQL SDL file 2`] = `
+"import type * as Scalar from "../../../../src/Schema/NamedType/Scalar/Scalar.js"
+
+declare global {
+  interface SchemaCustomScalars {
+    Date: Date
+  }
+}
+
+
+  export const Date = Scalar.scalar('Date', Scalar.nativeScalarConstructors.String)
+  export type Date = typeof Date
+        
+
+
+
+
+export * from "../../../../src/Schema/NamedType/Scalar/Scalar.js"
+"
 `;

--- a/tests/ts/generate.test.ts
+++ b/tests/ts/generate.test.ts
@@ -4,11 +4,15 @@ import { generateFile } from '../../src/generator/generator.js'
 
 test(`generates types from GraphQL SDL file`, async () => {
   await generateFile({
-    schemaModulePath: `../../../src/Schema/__.js`,
+    schemaModulePath: `../../../../src/Schema/__.js`,
+    scalarsModulePath: `../../../../src/Schema/NamedType/Scalar/Scalar.js`,
     schemaPath: `./tests/ts/_/schema.graphql`,
-    typeScriptPath: `./tests/ts/_/schema.ts`,
+    outputDirPath: `./tests/ts/_/schema`,
   })
   expect(
-    await readFile(`./tests/ts/_/schema.ts`, `utf8`),
+    await readFile(`./tests/ts/_/schema/Schema.ts`, `utf8`),
+  ).toMatchSnapshot()
+  expect(
+    await readFile(`./tests/ts/_/schema/Scalar.ts`, `utf8`),
   ).toMatchSnapshot()
 })


### PR DESCRIPTION
This PR brings primitive support for custom scalars. It permits them to show up in the schema at all, just as strings.